### PR TITLE
Error events can fire before the stream is resolved

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,11 @@ SftpClient.prototype.get = function(path, useCompression) {
 
         if (sftp) {
             try {
-                resolve(sftp.createReadStream(path, useCompression));
+                let stream = sftp.createReadStream(path, useCompression);
+
+                stream.on('error', reject);
+
+                resolve(stream);
             } catch(err) {
                 reject(err);
             }
@@ -105,9 +109,8 @@ SftpClient.prototype.put = function(input, remotePath, useCompression) {
             let stream = sftp.createWriteStream(remotePath, useCompression);
             let data;
 
-            stream.on('close', () => {
-                resolve();
-            });
+            stream.on('error', reject);
+            stream.on('close', resolve);
 
             if (input instanceof Buffer) {
                 data = stream.end(input);


### PR DESCRIPTION
In both `get` and `put` we can trigger an error before an error event handler can be attached in user's `resolve` handler. A good example being trying to get a non existent file.