### PR TITLE
Support for stream encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ group: // group ID
 ```
 
 #### Get
-get a new readable stream for path.
+get a new readable stream for path. The encoding is passed to Node Stream (https://nodejs.org/api/stream.html) and it controls how the content is encoded. For example, when downloading binary data, 'null' should be passed (check node stream documentation). Defaults to 'utf8'.
 
 ```
-sftp.get(romoteFilePath, [useCompression]);
+sftp.get(remoteFilePath, [useCompression], [encoding]);
 ```
 
 #### Put
 upload a file. it can be `localPath` or `Buffer` or `Stream`.
 
 ```
-sftp.put(localFilePath, remoteFilePath, [useCompression]);
-sftp.put(Buffer, remoteFilePath, [useCompression]);
-sftp.put(Stream, remoteFilePath, [useCompression]);
+sftp.put(localFilePath, remoteFilePath, [useCompression], [encoding]);
+sftp.put(Buffer, remoteFilePath, [useCompression], [encoding]);
+sftp.put(Stream, remoteFilePath, [useCompression], [encoding]);
 ```
 
 #### Mkdir

--- a/test/index.js
+++ b/test/index.js
@@ -260,3 +260,22 @@ describe('rename', () => {
         });
     });
 });
+
+describe('getOptions', () => {
+
+    it('encoding should be utf8 if undefined', () => {
+        return expect(sftp.getOptions(false)).to.have.property('encoding', 'utf8')
+    });
+    
+    it('encoding should be utf8 if undefined 2', () => {
+        return expect(sftp.getOptions(false, undefined)).to.have.property('encoding', 'utf8')
+    });
+    
+    it('encoding should be null if null', () => {
+        return expect(sftp.getOptions(false, null)).to.have.property('encoding', null)
+    });
+    
+    it('encoding should be hex', () => {
+        return expect(sftp.getOptions(false, 'hex')).to.have.property('encoding', 'hex')
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -262,8 +262,12 @@ describe('rename', () => {
 });
 
 describe('getOptions', () => {
-
+    
     it('encoding should be utf8 if undefined', () => {
+        return expect(sftp.getOptions()).to.have.property('encoding', 'utf8')
+    });
+
+    it('encoding should be utf8 if undefined 1', () => {
         return expect(sftp.getOptions(false)).to.have.property('encoding', 'utf8')
     });
     


### PR DESCRIPTION
Support for stream encodings. The previous implementation forced 'utf8' which did not work well with binary data. New implementation allows to pass optional parameter 'encoding' to get() and put() methods. If 'encoding' is undefined, it will default to 'utf8'.

The change is backwards compatible.