### PR TITLE
Ignore error code 11 'File already exists' when recursively creating directories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ SftpClient.prototype.mkdir = function(path, recursive) {
                 token += '/';
                 p = p + token;
                 sftp.mkdir(p, (err) => {
-                    if (err && err.code !== 4) {
+                    if (err && ![4, 11].includes(err.code)) {
                         reject(err);
                     }
                     mkdir();


### PR DESCRIPTION
Most sftp servers use error code 4 'Failure' for everything but some use a wider range of errors.  See here: https://winscp.net/eng/docs/sftp_codes

Error code 11 means 'File already exists' and should be ignored when recursively creating directories.