### PR TITLE
Changed async/await methods to Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "email": "jyu213@gmail.com",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.2",
     "ssh2": "^0.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "email": "jyu213@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.5.2",
     "ssh2": "^0.6.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
 
 const Client = require('ssh2').Client;
 const osPath = require('path');
-const BluebirdPromise = require('bluebird');
+const utils = require('./utils');
 
 let SftpClient = function(){
   this.client = new Client();
@@ -338,11 +338,11 @@ SftpClient.prototype.rmdir = function(path, recursive = false) {
       list = res;
       files = list.filter(item => item.type === '-');
       dirs = list.filter(item => item.type === 'd');
-      return BluebirdPromise.each(files, (f) => {
+      return utils.forEachPromise(files, (f) => {
         return this.delete(osPath.join(p, f.name));
       });
     }).then(() => {
-      return BluebirdPromise.each(dirs, (d) => {
+      return utils.forEachPromise(dirs, (d) => {
         return rmdir(osPath.join(p, d.name));
       });
     }).then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -338,11 +338,11 @@ SftpClient.prototype.rmdir = function(path, recursive = false) {
       list = res;
       files = list.filter(item => item.type === '-');
       dirs = list.filter(item => item.type === 'd');
-      return utils.forEachPromise(files, (f) => {
+      return utils.forEachAsync(files, (f) => {
         return this.delete(osPath.join(p, f.name));
       });
     }).then(() => {
-      return utils.forEachPromise(dirs, (d) => {
+      return utils.forEachAsync(dirs, (d) => {
         return rmdir(osPath.join(p, d.name));
       });
     }).then(() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+var exports = module.exports;
+
+exports.forEachPromise = function(array, callback) {
+  return new Promise((resolve, reject) => {
+    if (array.length == 0) {
+      return resolve();
+    }
+    return callback(array[0]).then(() => {
+      return exports.forEachPromise(array.slice(1), callback).then(resolve);
+    }).catch(reject);
+  });
+}
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,10 @@
 var exports = module.exports;
 
-exports.forEachPromise = function(array, callback) {
-  return new Promise((resolve, reject) => {
-    if (array.length == 0) {
-      return resolve();
-    }
-    return callback(array[0]).then(() => {
-      return exports.forEachPromise(array.slice(1), callback).then(resolve);
-    }).catch(reject);
-  });
+exports.forEachAsync = function(array, callback) {
+  return array.reduce((promise, item) => {
+    return promise.then((result) => {
+      return callback(item);
+    });
+  }, Promise.resolve());
 }
 


### PR DESCRIPTION
This maintains support with older versions of NodeJS, as some linux distributions (CentOS) still have older versions of NodeJS which don't support async/await syntax.

Btw, I did not test these methods very much, but I trust the person who wrote the tests, as it still passes them 100%.