### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sftp.on('error', callbackFn)
 
 ### Log
 #### V2.4.0
-Requires node.js v6 or above.
+Requires node.js v7.5.0 or above.
 
     - merge pr #97, thanks for @theophilusx
         - Remove emmitter.maxListener warnings

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ sftp.on('error', callbackFn)
 
 ### Log
 #### V2.4.0
+Requires node.js v6 or above.
+
     - merge pr #97, thanks for @theophilusx
         - Remove emmitter.maxListener warnings
         - Upgraded ssh2 dependency from 0.5.5 to 0.6.1


### PR DESCRIPTION
[This](https://github.com/jyu213/ssh2-sftp-client/blob/master/src/index.js#L78) will cause failures in older versions of node:
```
SyntaxError: Unexpected token {
```
I suppose that instead of mentioning node version compatibility here, you could:
- remove destructuring from `https://github.com/jyu213/ssh2-sftp-client/blob/master/src/index.js`
- transpile `index.js` to output an older version of js before packaging