### PR TITLE
use posix path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const Client = require('ssh2').Client;
-const osPath = require('path');
+const osPath = require('path').posix;
 const utils = require('./utils');
 
 let SftpClient = function(){


### PR DESCRIPTION
Remote directory separator must be "/", like posix (see https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-6)
Then use `require('path').posix` instead of `require('path')`