### PR TITLE
Fix `get` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ group: // group ID
 ```
 
 #### Get
-Get a ReadableStream from remotePath. The encoding is passed to Node Stream (https://nodejs.org/api/stream.html) and it controls how the content is encoded. For example, when downloading binary data, 'null' should be passed (check node stream documentation). Default to 'utf8'.
+Get a `ReadableStream` from remotePath. The encoding is passed to Node Stream (https://nodejs.org/api/stream.html) and it controls how the content is encoded. For example, when downloading binary data, 'null' should be passed (check node stream documentation). Default to 'utf8'.
 
 ```javascript
 sftp.get(remoteFilePath, [useCompression], [encoding], [addtionalOptions]);

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ group: // group ID
 ```
 
 #### Get
-Get a Chunk from remotePath. The encoding is passed to Node Stream (https://nodejs.org/api/stream.html) and it controls how the content is encoded. For example, when downloading binary data, 'null' should be passed (check node stream documentation). Default to 'utf8'.
+Get a ReadableStream from remotePath. The encoding is passed to Node Stream (https://nodejs.org/api/stream.html) and it controls how the content is encoded. For example, when downloading binary data, 'null' should be passed (check node stream documentation). Default to 'utf8'.
 
 ```javascript
 sftp.get(remoteFilePath, [useCompression], [encoding], [addtionalOptions]);


### PR DESCRIPTION
The readme had the old v3 description for `get`