### PR TITLE
Reject connect() promise if connection ends

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -451,6 +451,7 @@ SftpClient.prototype.connect = function(config, connectMethod) {
     this.client[connectMethod]('ready', () => {
       this.client.sftp((err, sftp) => {
         this.client.removeListener('error', reject);
+        this.client.removeListener('end', reject);
         if (err) {
           reject(new Error(`Failed to connect to server: ${err.message}`));
         }
@@ -458,6 +459,7 @@ SftpClient.prototype.connect = function(config, connectMethod) {
         resolve(sftp);
       });
     })
+      .on('end', reject)
       .on('error', reject)
       .connect(config);
   });


### PR DESCRIPTION
This change causes SFTPClient.prototype.connect to reject the returned promise if the underlying SSH client closes in the meantime, before the SFTP subsystem is ready.

In some cases (notably, upon getting a TCP RST), the client would emit an `end` event and become inactive, ignoring further requests. However, since no `error` was being emitted from the client object, connect() would not fail, instead hanging indefinitely.

For jyu213/ssh2-sftp-client#109