### PR TITLE
Update ssh2 dependency to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "email": "jyu213@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "ssh2": "^0.6.1"
+    "ssh2": "^0.8.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Version `0.8.2` of the `ssh2` package includes updates from the `ssh2-stream` dependency for parsing private keys.  Additional private key formats (including the "new" OpenSSH key format) are now supported with this version bump.

After upgrading the `ssh2` package, the existing unit tests pass.