### PR TITLE
Update README.md to call out put() requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sftp.fastGet(remotePath, localPath, [options]);
 ```
 
 #### Put
-upload a file from `localPath` or `Buffer`, `Stream` data to `remoteFilePath`.The encoding is passed to Node Stream to control how the content is encoded. Default to 'utf8'.
+upload a file from `localPath` or `Buffer`, `Stream` data to `remoteFilePath`.The encoding is passed to Node Stream to control how the content is encoded. Default to 'utf8'. **Be sure to include the file name in remoteFilePath!**
 
 ```javascript
 sftp.put(localFilePath, remoteFilePath, [optons]);


### PR DESCRIPTION
To avoid a "failed to upload" error, you have to put the target file name as well as the path.