### PR TITLE
Adding retry to connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "concat-stream": "^2.0.0",
-    "ssh2": "^0.8.2"
+    "ssh2": "^0.8.2",
+    "retry": "^0.10.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Adding Retry functionality to connect

Pass extra key to config:

config = {
   host: "",
   ....,
   retries: 1 //Seting this to 1 means do it once, then retry it 1 times, i.e. (retries + 1) 2 times
}