### PR TITLE
Add a base case to mkdir recursive, prevent infinite looping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ssh2-sftp-client",
-  "version": "2.4.3",
-  "description": "ssh2 sftp client for node",
+  "name": "ssh2-sftp-client-mkdir-patch",
+  "version": "2.4.4",
+  "description": "ssh2 sftp client for node. With mkdir recursive patch",
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jyu213/ssh2-sftp-client"
+    "url": "https://github.com/theryaz/ssh2-sftp-client"
   },
   "keywords": [
     "sftp",

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ SftpClient.prototype.list = function(path) {
  * Retrieves a directory listing with a filter
  *
  * @param {String} path, a string containing the path to a directory
- * @param {String} pattern, a string containing the path 
+ * @param {String} pattern, a string containing the path
  * @return {Promise} data, list info
  */
 SftpClient.prototype.auxList = function (path, pattern='*') {
@@ -113,7 +113,7 @@ SftpClient.prototype.auxList = function (path, pattern='*') {
 
 /**
  * @async
- 
+
  * Tests to see if an object exists. If it does, return the type of that object
  * (in the format returned by list). If it does not exist, return false.
  *
@@ -427,6 +427,9 @@ SftpClient.prototype.mkdir = function(path, recursive = false) {
   }
   let mkdir = p => {
     let {dir} = osPath.parse(p);
+    if(dir === ''){
+      return;
+    }
     return this.exists(dir)
       .then(type => {
         if (!type) {

--- a/src/index.js
+++ b/src/index.js
@@ -427,7 +427,7 @@ SftpClient.prototype.mkdir = function(path, recursive = false) {
   }
   let mkdir = p => {
     let {dir} = osPath.parse(p);
-    if(dir === ''){
+    if(dir === '' || dir === '/' || dir === '.'){
       return;
     }
     return this.exists(dir)


### PR DESCRIPTION
I ran into an infinite loop when trying to use recursive mkdir without proper permissions. I did some tests and found if I add this base-case it behaves as expected, throwing a "Permission denied" error.